### PR TITLE
Add convertFromDuration unit test

### DIFF
--- a/app/src/test/java/com/example/beatflowplayer/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/beatflowplayer/ExampleUnitTest.kt
@@ -1,8 +1,8 @@
 package com.example.beatflowplayer
 
 import org.junit.Test
-
 import org.junit.Assert.*
+import com.example.beatflowplayer.utils.convertFromDuration
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -11,7 +11,8 @@ import org.junit.Assert.*
  */
 class ExampleUnitTest {
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun convertFromDuration_returnsFormattedTime() {
+        val result = convertFromDuration(125000)
+        assertEquals("2:05", result)
     }
 }


### PR DESCRIPTION
## Summary
- replace placeholder test with check for `convertFromDuration`

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416d4593108324a0f621d27e0751cb